### PR TITLE
Split pattern args with whitespace characters

### DIFF
--- a/cmd/ghglob/main.go
+++ b/cmd/ghglob/main.go
@@ -54,7 +54,10 @@ func main() {
 }
 
 func glob() {
-	ps := flag.Args()
+	var ps []string
+	for _, arg := range flag.Args() {
+		ps = append(ps, strings.Fields(arg)...)
+	}
 	if !*all && shouldIgnoreDot(ps) {
 		ps = append(ps, "!**/.**")
 	}


### PR DESCRIPTION
Patterns should actually allow whitespace because whitespace is allowd
in file name, but it should be useful for 99.9% cases.

e.g.

$ PATTERNS="**.go **.md"
$ ghglob "${PATTERN}"

Note that without quoting $PATTERN, shell expand star before passing it
to ghglob command.